### PR TITLE
Handle unmatched trades in cci_trade

### DIFF
--- a/algo_trading.py
+++ b/algo_trading.py
@@ -5,7 +5,7 @@ import numpy as np
 import talib
 from matplotlib import pyplot as plt
 from sklearn.svm import SVR
-import sys,os
+import sys, os
 
 class algo_trading(object):
     
@@ -88,10 +88,22 @@ class algo_trading(object):
             else:
                 pass   
         
-        if buy[-1]>sell[-1]:
-            del buy[-1]
-            del sell[-1]
-            del activity[-1]
+        # Ensure trade lists are balanced. It's possible to end the loop with a
+        # buy that was never sold, which previously raised an IndexError when
+        # trying to access ``sell[-1]``. Drop any unmatched trades along with
+        # their associated fees and activity markers.
+        while len(buy) > len(sell):
+            buy.pop()
+            if fee:
+                fee.pop()
+            if activity:
+                activity.pop()
+        while len(sell) > len(buy):
+            sell.pop()
+            if fee:
+                fee.pop()
+            if activity:
+                activity.pop()
         
             
         trading = len(buy)+len(sell)    


### PR DESCRIPTION
## Summary
- Prevent `IndexError` in `cci_trade` by ensuring buy/sell lists are balanced before calculating returns

## Testing
- `python -m py_compile algo_trading.py`


------
https://chatgpt.com/codex/tasks/task_e_6895da6705c4832f968f9ed7588ae211